### PR TITLE
bringing same visibility properties from AweConnectLine

### DIFF
--- a/connectors/AweConnectPoint.cm
+++ b/connectors/AweConnectPoint.cm
@@ -46,4 +46,10 @@ public class AweConnectPoint extends ConnectPoint {
     extend public bool shouldRealign() {
         return this.realign;
     }
+
+    public bool hidden = false;
+    public bool hiddenWhenDisconnected = false;
+    public bool isVisible() {
+        return !hidden and !((hiddenWhenDisconnected and !this.isConnected()));
+    }
 }


### PR DESCRIPTION
Now you have the same options to hide the connectors. AweConnectLine already had those properties.