### PR TITLE
Fixing copy=ref on Snappers.

### DIFF
--- a/AweEasySnapper.cm
+++ b/AweEasySnapper.cm
@@ -48,10 +48,10 @@ public class AweEasySnapper extends AweSnapper : abstract {
         this.refresh();
     }
 
-    public AweProduct product : copy=reference;
+    public AweProduct product;
     extend public AweProduct createProduct(AweObject configurator) : abstract { }
 
-    public AweObject configurator : copy=reference;
+    public AweObject configurator;
     extend public AweObject createConfigurator() : abstract { }
 
     public AweProduct[] allProducts() {

--- a/AweSnapper.cm
+++ b/AweSnapper.cm
@@ -52,7 +52,7 @@ public class AweSnapper  extends Snapper {
     public constructor() { 
     }
 
-    public AweObject activeConfigurator : copy=reference;
+    public AweObject activeConfigurator;
 
     extend public AweObject[] allModels() {
         return new AweObject[]();


### PR DESCRIPTION
Make it so the when a snapper is copied it doesn't copy the model or the product, otherwise changing one changes both of them.