### PR TITLE
More custom toS

### DIFF
--- a/AweObject.cm
+++ b/AweObject.cm
@@ -38,6 +38,10 @@ package custom.awesome;
 
 use cm.syntax;
 
+public class ToStrShell extends AweDynamicShell {
+    public aweShellMethod str toStr(str extraInfo);
+}
+
 public class AweObject {
     public str->Object props();
     public str _galleryId;
@@ -149,9 +153,9 @@ public class AweObject {
                 } else {
                     str value = ""; 
                     if (target) { 
-                        var formattedValue = aweDynamicCall target.toStr(extraParam);
-                        if (formattedValue and (formattedValue.str)) { 
-                            value = formattedValue.str;
+                        var formattedValue = ToStrShell(target).toStr(extraParam);
+                        if (formattedValue != null) { 
+                            value = formattedValue;
                         } else { 
                             value = target.toS();
                         }
@@ -388,39 +392,4 @@ public member @visibility aweObjectDomain @domains=formalArgList ';' {
             @animationPropertiesChanged;
         }
     };
-}
-
-public aweObject Testing { 
-    props (
-        str test = "",
-        MyClass myClass = MyClass()
-    );
-}
-
-public class MyClass { 
-    
-    public aweDynamicContract {
-        aweDynamic str toStr(str extraInfo);
-    }
-
-    public double value = 123.123455;
-    public str something;
-    
-    public constructor() { 
-
-    }
-
-    public str toS() { 
-        return "Ops";
-    }
-
-    extend public str toStr(str extraInfo) { 
-        return "Okdok: " # value # "[" # extraInfo # "]";
-    }
-}
-
-{ 
-    Testing t();
-    var f = "Hi from {myClass:something important!}.";
-    pln(#t.toS(f));
 }

--- a/AweObject.cm
+++ b/AweObject.cm
@@ -410,6 +410,10 @@ public class MyClass {
 
     }
 
+    public str toS() { 
+        return "Ops";
+    }
+
     extend public str toStr(str extraInfo) { 
         return "Okdok: " # value # "[" # extraInfo # "]";
     }
@@ -417,6 +421,6 @@ public class MyClass {
 
 { 
     Testing t();
-    var f = "Hi from {myClass:bolinha verde}.";
+    var f = "Hi from {myClass:something important!}.";
     pln(#t.toS(f));
 }

--- a/AweObject.cm
+++ b/AweObject.cm
@@ -115,6 +115,7 @@ public class AweObject {
                 capture = false;
 
                 Int precision;
+                str extraParam;
                 var originalToken = token;
                 var toInches = false;
                 if (token.indexOf(":") > -1) { 
@@ -128,6 +129,9 @@ public class AweObject {
                         }
                     } else { 
                         precision = data.v1.toInt;
+                        if (!precision) { 
+                            extraParam = data.v1.toS;
+                        }
                     }
                 }
 
@@ -145,7 +149,7 @@ public class AweObject {
                 } else {
                     str value = ""; 
                     if (target) { 
-                        var formattedValue = aweDynamicCall target.toStr();
+                        var formattedValue = aweDynamicCall target.toStr(extraParam);
                         if (formattedValue and (formattedValue.str)) { 
                             value = formattedValue.str;
                         } else { 
@@ -386,7 +390,6 @@ public member @visibility aweObjectDomain @domains=formalArgList ';' {
     };
 }
 
-
 public aweObject Testing { 
     props (
         str test = "",
@@ -397,7 +400,7 @@ public aweObject Testing {
 public class MyClass { 
     
     public aweDynamicContract {
-        aweDynamic str toStr();
+        aweDynamic str toStr(str extraInfo);
     }
 
     public double value = 123.123455;
@@ -407,17 +410,13 @@ public class MyClass {
 
     }
 
-    // public str toS() { 
-    //     return "Ops..";
-    // }
-
-    extend public str toStr() { 
-        return "Okdok: " # value;
+    extend public str toStr(str extraInfo) { 
+        return "Okdok: " # value # "[" # extraInfo # "]";
     }
 }
 
 { 
     Testing t();
-    var f = "Hi from {myClass}.";
+    var f = "Hi from {myClass:bolinha verde}.";
     pln(#t.toS(f));
 }

--- a/AweObject.cm
+++ b/AweObject.cm
@@ -142,8 +142,17 @@ public class AweObject {
                     } else { 
                         formattedData.put(token, "");
                     }
-                } else { 
-                    formattedData.put(token, target ? target.toS : "");
+                } else {
+                    str value = ""; 
+                    if (target) { 
+                        var formattedValue = aweDynamicCall target.toStr();
+                        if (formattedValue and (formattedValue.str)) { 
+                            value = formattedValue.str;
+                        } else { 
+                            value = target.toS();
+                        }
+                    }
+                    formattedData.put(token, value);
                 }
 
                 format = format.replaceAll("{" # originalToken # "}",  "{" # token # "}");
@@ -375,4 +384,40 @@ public member @visibility aweObjectDomain @domains=formalArgList ';' {
             @animationPropertiesChanged;
         }
     };
+}
+
+
+public aweObject Testing { 
+    props (
+        str test = "",
+        MyClass myClass = MyClass()
+    );
+}
+
+public class MyClass { 
+    
+    public aweDynamicContract {
+        aweDynamic str toStr();
+    }
+
+    public double value = 123.123455;
+    public str something;
+    
+    public constructor() { 
+
+    }
+
+    // public str toS() { 
+    //     return "Ops..";
+    // }
+
+    extend public str toStr() { 
+        return "Okdok: " # value;
+    }
+}
+
+{ 
+    Testing t();
+    var f = "Hi from {myClass}.";
+    pln(#t.toS(f));
 }


### PR DESCRIPTION
#### Say you have a class:
```Java
public aweObject Testing { 
    props (
        str test = "",
        MyClass myClass = MyClass()
    );
}
```

#### And you need a custom `toS` on `MyClass`. Now you can do the following:
Using this contract:
```Java
public class ToStrShell extends AweDynamicShell {
    public aweShellMethod str toStr(str extraInfo);
}
```

And this class
```Java
public class MyClass { 
    
    public aweDynamicContract {
        aweDynamic str toStr(str extraInfo);
    }

    public double value = 123.123455;
    public str something;
    
    public constructor() { 

    }

    public str toS() { 
        return "Ops";
    }

    extend public str toStr(str extraInfo) { 
        return "Okdok: " # value # "[" # extraInfo # "]";
    }
}
```

#### Test it like so:
```Java
{ 
    Testing t();
    var f = "Hi from {myClass:something important!}.";
    pln(#t.toS(f));
}
```

#### The output will be
```Console
run("c:/CetDev/version7.5/home/custom/awesome/AweObject.cm");
t.toS(f)=Hi from Okdok: 123.123[something important!].
cm> 
```