### PR TITLE
adding top/bottom gap on storage doors

### DIFF
--- a/storage/AweStorageCasterBase.cm
+++ b/storage/AweStorageCasterBase.cm
@@ -60,6 +60,7 @@ public class AweStorageCasterBase extends AweStorageBase {
     extend public Awe3D addCaster(point2D position) {
         Awe3D prims();
         prims << Awe3D(addWheels, addMount).move((position.x, position.y, 0)).rotate(90deg);
+        prims.setMaterial(material);
         return Awe3D(prims);
     }
 

--- a/storage/AweStorageDoor.cm
+++ b/storage/AweStorageDoor.cm
@@ -1,3 +1,4 @@
+
 /** Configura CET Source Copyright Notice (CETSC)
 
    This file contains Configura CM source code and is part of the
@@ -41,15 +42,19 @@ public class AweStorageDoor extends AweStorageGridPiece {
     public bool writeable;
     public double leftOffset;
     public double rightOffset;
+    public double topOffset;
+    public double bottomOffset;
     public AwePullType pullType;
     private Point2D _pullPosition;
     private bool useLargeIfPossible;
 
-    public constructor(awePullType pullType, bool writeable = false, double leftOffset = 0, double rightOffset = 0, bool useLargeIfPossible = false) {
+    public constructor(awePullType pullType, bool writeable = false, double leftOffset = 0.03125inch, double rightOffset = 0.03125inch, double topOffset = 0.03125inch, double bottomOffset = 0.03125inch, bool useLargeIfPossible = false) {
         this.pullType = pullType;
         this.writeable = writeable;
         this.leftOffset = leftOffset;
         this.rightOffset = rightOffset;
+        this.topOffset = topOffset;
+        this.bottomOffset = bottomOffset;
         this.useLargeIfPossible = useLargeIfPossible;
     } 
 
@@ -90,7 +95,7 @@ public class AweStorageDoor extends AweStorageGridPiece {
             prims << writeableFront;
         }
 
-        prims << AweBox3D(box((0 + leftOffset, 0, 0), (width - rightOffset, depth, height)), owner.getMaterial("front"));
+        prims << AweBox3D(box((0 + leftOffset, 0, bottomOffset), (width - rightOffset, depth, height - topOffset)), owner.getMaterial("front"));
         return Awe3D(prims);
     }
 


### PR DESCRIPTION
Added properties that control gaps on each side of storage doors.
Default value set to 1/32".

<img width="1195" alt="drawer-gap" src="https://cloud.githubusercontent.com/assets/14116090/26405442/b5b77e70-406b-11e7-8192-7662183f46b3.png">
