### PR TITLE
Adding nameof syntax

### DIFF
--- a/nameof.syntax.cm
+++ b/nameof.syntax.cm
@@ -1,0 +1,54 @@
+/** Configura CET Source Copyright Notice (CETSC)
+
+   This file contains Configura CM source code and is part of the
+   Configura CET Development Platform (CETDEV). Configura CM
+   is a programming language created by Configura Sverige AB.
+   Configura, Configura CET and Configura CM are trademarks of
+   Configura Sverige AB. Configura Sverige AB owns Configura CET,
+   Configura CM, and CETDEV.
+
+   Copyright (C) 2004 Configura Sverige AB, All rights reserved.
+
+   You can modify this source file under the terms of the Configura CET
+   Source Licence Agreement (CETSL) as published by Configura Sverige AB.
+
+   Configura Sverige AB has exclusive rights to all changes, modifications,
+   and corrections of this source file. Configura Sverige AB has exclusive
+   rights to any new source file containing material from this source file.
+   A new source file based on this source file or containing material from
+   this source file has to include this Configura CET Source Copyright Notice
+   in its full content. All changes, modifications, and corrections mentioned
+   above shall be reported to Configura Sverige AB within One Month from
+   the date that the modification occurred.
+
+   Configura CM is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+   See the CETSL for more details.
+
+   You should have received a copy of the CETSL along with the CETDEV.
+   If not, write to Configura Sverige AB, Box 306, SE-581 02 Linköping, Sweden.
+   Tel +46 13377800, Fax +46 13377855,
+   Email: info@configura.com, www.configura.com
+
+   END OF CETSC
+*/
+
+package custom.awesome;
+
+use cm.syntax;
+
+public expr nameof '(' @val=expr ')' {
+    SId id = val.id;
+    str name = id.name;
+    if ( val.type.toS == "void" ) {
+        return expr {{ 
+            result @name;
+        }};
+    } else {
+        return expr {{ 
+            Object x = @val;
+            result @name;
+        }};
+    }
+}


### PR DESCRIPTION
Adding a syntax for `nameof`.  This works similar to the C# one that basically outputs the variable name as a string.  This can be helpful to avoid hard coding strings passing to method.  

Allows you to write code such as

```java
double x =5;
pln( nameof( x ) ); // outputs 'x'
```

This also works with chained dot calls such as

```java
TestClass c();

pln( nameof( c.fullName ) ); // outputs `fullName`
```
It will give a compiler error if you pass in a variable that does not exist.  That way if you change the name of the variable these will fail to compile, whereas if you used a string instead, it will still compile and just have weird runtime problems.