### PR TITLE
Adding platform base

### DIFF
--- a/storage/AweStoragePlatformBase.cm
+++ b/storage/AweStoragePlatformBase.cm
@@ -37,18 +37,23 @@
 package custom.awesome.storage;
 
 public class AweStoragePlatformBase extends AweStorageBase {
-    private double extraWidth;
+    private double baseTrim;
     
-    public constructor(double height, double extraWidth=0) {
+    public constructor(double height=3.39inch, double baseTrim=.730inch) {
         this.height = height;
-        this.extraWidth = extraWidth;
+        this.baseTrim = baseTrim;
     }   
 
     public Awe3D get3D() {        
         Awe3D prims();
-        box b((owner.localBound.p0.x, owner.localBound.p0.y - this.extraWidth, owner.localBound.p0.z), (owner.localBound.p1.x, owner.localBound.p1.y, this.height));
 
-        prims << Box3D(b);
+        double tinyOffset = .20inch;
+        
+        box platform((owner.localBound.p0.x, owner.localBound.p0.y, owner.localBound.p0.z), (owner.localBound.p1.x, owner.localBound.p1.y, this.height));
+        box baseTrim((owner.localBound.p0.x + tinyOffset, owner.localBound.p0.y - this.baseTrim , owner.localBound.p0.z), (owner.localBound.p1.x - tinyOffset, owner.localBound.p0.y, this.height + this.baseTrim));
+
+        prims << Box3D(platform);
+        prims << Box3D(baseTrim);
 
         prims.setMaterial(material);
 

--- a/storage/AweStoragePlatformBase.cm
+++ b/storage/AweStoragePlatformBase.cm
@@ -1,0 +1,57 @@
+/** Configura CET Source Copyright Notice (CETSC)
+
+   This file contains Configura CM source code and is part of the
+   Configura CET Development Platform (CETDEV). Configura CM
+   is a programming language created by Configura Sverige AB.
+   Configura, Configura CET and Configura CM are trademarks of
+   Configura Sverige AB. Configura Sverige AB owns Configura CET,
+   Configura CM, and CETDEV.
+
+   Copyright (C) 2004 Configura Sverige AB, All rights reserved.
+
+   You can modify this source file under the terms of the Configura CET
+   Source Licence Agreement (CETSL) as published by Configura Sverige AB.
+
+   Configura Sverige AB has exclusive rights to all changes, modifications,
+   and corrections of this source file. Configura Sverige AB has exclusive
+   rights to any new source file containing material from this source file.
+   A new source file based on this source file or containing material from
+   this source file has to include this Configura CET Source Copyright Notice
+   in its full content. All changes, modifications, and corrections mentioned
+   above shall be reported to Configura Sverige AB within One Month from
+   the date that the modification occurred.
+
+   Configura CM is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+   See the CETSL for more details.
+
+   You should have received a copy of the CETSL along with the CETDEV.
+   If not, write to Configura Sverige AB, Box 306, SE-581 02 Linköping, Sweden.
+   Tel +46 13377800, Fax +46 13377855,
+   Email: info@configura.com, www.configura.com
+
+   END OF CETSC
+*/
+
+package custom.awesome.storage;
+
+public class AweStoragePlatformBase extends AweStorageBase {
+    private double extraWidth;
+    
+    public constructor(double height, double extraWidth=0) {
+        this.height = height;
+        this.extraWidth = extraWidth;
+    }   
+
+    public Awe3D get3D() {        
+        Awe3D prims();
+        box b((owner.localBound.p0.x, owner.localBound.p0.y - this.extraWidth, owner.localBound.p0.z), (owner.localBound.p1.x, owner.localBound.p1.y, this.height));
+
+        prims << Box3D(b);
+
+        prims.setMaterial(material);
+
+        return Awe3D(prims);
+    }
+}


### PR DESCRIPTION
Creating a new platform base for storage that needs a solid foundation before the shelves and other things. Accepts the `height` and `baseTrim` that is a number of inches that the platform goes out from the main chassis.

Made to address this issue: https://github.com/Allsteel/storage-cet-extension/issues/42

From this:

![image](https://user-images.githubusercontent.com/111954/27303664-2e5a99bc-5501-11e7-8ebd-52a938ef46c2.png)

To this:

![image](https://user-images.githubusercontent.com/111954/27307101-c213e81e-550d-11e7-8ea3-fab5ddebf76d.png)

Usage:

```java
chassis.addBase(AweStoragePlatformBase(), getMaterial3D(this.model.palette, model.material))
```

