### PR TITLE
Storage Asymmetrical Septum Placement

### DIFF
--- a/storage/AweStorageGrid.cm
+++ b/storage/AweStorageGrid.cm
@@ -162,7 +162,7 @@ public class AweStorageGrid {
              if (c.septum) {
                 //See comments below about base - It might interfere here
 
-                c.septum.move((0, localBound.p0.y, localBound.p0.z));
+                c.septum.move((-localBound.p1.x + c.width, localBound.p0.y, localBound.p0.z));
                 if(!c.septum.mainMaterial) c.septum.setMaterial(getMaterial("septum"));
                 prim << c.septum;
             }

--- a/storage/AweStorageGrid.cm
+++ b/storage/AweStorageGrid.cm
@@ -162,7 +162,7 @@ public class AweStorageGrid {
              if (c.septum) {
                 //See comments below about base - It might interfere here
 
-                c.septum.move((-localBound.p1.x + c.width, localBound.p0.y, localBound.p0.z));
+                c.septum.move((-localBound.p1.x + c.width + c.septum.thickness/2, localBound.p0.y, localBound.p0.z));
                 if(!c.septum.mainMaterial) c.septum.setMaterial(getMaterial("septum"));
                 prim << c.septum;
             }

--- a/storage/AweStorageGridPiece.cm
+++ b/storage/AweStorageGridPiece.cm
@@ -56,7 +56,7 @@ public class AweStorageGridPiece {
     }   
 
     extend public Awe3D get3D() {
-        AweBox3D aweBox(box((leftOffset, 0, bottomOffset), (width - rightOffset,depth,height - topOffset)), this.material??randomColorLWMaterial);
+        AweBox3D aweBox(box((leftOffset, 0, bottomOffset), (width - rightOffset,depth,height - topOffset)), this.material??owner.getMaterial("front"));
         return aweBox;
     }
 


### PR DESCRIPTION
Places the septum after the column and not always on the middle of the box passed as a parameter to it. This allows asymmetrical grids as the ones in _Side Access Towers_:

![septum](https://user-images.githubusercontent.com/18706959/27495570-cd070a4e-5828-11e7-88a6-dd7ec27b2b3b.gif)
