### PR TITLE
query dialog should not be closed when there is no parts anymore

### DIFF
--- a/AweQueryDialog.cm
+++ b/AweQueryDialog.cm
@@ -150,7 +150,42 @@ public class AweQueryDialog extends GoQueryDialog {
     public void refreshContent() {
         this.toggleRemoveSpecialsButton();
 
-        super();
+        Snapper owner;
+	
+        if (this.owners and this.owners.any()) {
+            owner = this.owners.first();
+        }
+        
+        if (owner) {
+            SpaceSelection to = owner.space ? owner.space.selection : null;
+            Snapper[] ss();
+            
+            if (to) {
+                if (this.multiMode and to.snappers) {
+                    for (s in to.snappers) {
+                        ss << s;
+                    }
+                }
+                else if (to.main) {
+                    ss << to.main;
+                }
+            }
+            
+            if (ss.count() > 0) {
+                owners = ss;
+                this.parts = null;
+                
+                this.rebuildSubs();
+            }
+            
+            if (!parts or parts.empty) {
+                if (to and to.main) {
+                    to.main.popupMenuItemClicked(null,
+                        new MenuCallbackEnv("query-dialog", null,
+                        null, null, null));
+                }
+            }
+        }
     }
 
     extend private void toggleRemoveSpecialsButton() {


### PR DESCRIPTION
Closes Allsteel/acs-cet-extension#1170