### PR TITLE
Fix "null reference exception" on null AweEnum typed variables

### DIFF
--- a/AweEnum.cm
+++ b/AweEnum.cm
@@ -110,6 +110,7 @@ public class AweEnum extends AweEnumBase : abstract {
     }
     
     public bool equal(Object other, EqualEnv env=EqualEnv()) {
+
         if (other as AweEnum) {
             return this.class == other.class and this.name == other.name;
         }
@@ -121,7 +122,8 @@ public class AweEnum extends AweEnumBase : abstract {
         return super(..);
     }
 
-    extend public bool operator==(Object other) {
+    extend public bool operator==(Object other) : null=false {
+
         return this.equal(other);
     }
 

--- a/extension.cm
+++ b/extension.cm
@@ -140,8 +140,6 @@ package ExtensionInfo getExtensionInfo() : referred {
         files << f;
     }
 
-    files << cmFindUrl("custom/awesome/resources/main.rs");
-
     info.filesToInclude = files;
 
     return info;

--- a/materials/AweMaterial.cm
+++ b/materials/AweMaterial.cm
@@ -35,7 +35,6 @@
 */
 
 package custom.awesome.materials;
-use custom.acs.framework.materials;
 
 public class AweMaterial extends OfficeMaterial {
     private Image thumbnailCache : stream = null, copy = null;


### PR DESCRIPTION
Just added ` : null=false` at the end of line [125](https://github.com/Allsteel/awesome/compare/master...felipegtx:master#diff-36a973152f52126271ff76d6bfc6869fR125)