### PR TITLE
AweObject Improvements (Required for Cadence Typicals)

### DIFF
--- a/AweObject.cm
+++ b/AweObject.cm
@@ -47,6 +47,7 @@ public class AweObject {
     public str->Object props() : copy=null;
     public str _galleryId;
     public str _label;
+    public bool buildParentQuickProperties;
 
     //used to expose multiple aweObjects at once in quick properties
     public str _uniqueQuickPropertyId;
@@ -412,12 +413,12 @@ public class AweObject {
     }
 
     extend public bool buildQuickProperties(QuickProperties props) {
-        this.parent.?buildQuickProperties(props);
+        if (this.buildParentQuickProperties) this.parent.?buildQuickProperties(props);
         
         this.buildQuickPropertiesFromSyntax(props);
         this.buildConnectorSetProperties(props);
         this.sortQuickProperties(props);
-        this.parent.?sortQuickProperties(props);
+        if (this.buildParentQuickProperties) this.parent.?sortQuickProperties(props);
         
         return props and props.properties.any();
     }
@@ -433,8 +434,10 @@ public class AweObject {
     }
 
     extend public bool quickPropertyChanged(QuickProperties props, str key, Object value, bool testChangeOnly) {
-        if (this.parent.?quickPropertyChanged(..)) {
-            return true;
+        if (this.buildParentQuickProperties) {
+            if (this.parent.?quickPropertyChanged(..)) {
+                return true;
+            }
         }
 
         var changed = false;

--- a/AweObject.cm
+++ b/AweObject.cm
@@ -117,6 +117,10 @@ public class AweObject {
 
         if(oldValue.equal(value)) return;
         
+        if (value as AweObject) {
+            value.parent = this;
+        }
+
         //AweMaterialShell instance must never be replaced. instead, update the contents of the shell
         if (value in AweMaterialShell and oldValue in AweMaterialShell) {
             oldValue.AweMaterialShell.setMaterial(value.AweMaterialShell.materialInstance());
@@ -128,6 +132,10 @@ public class AweObject {
         }
 
         propChanged(propName, oldValue, value);
+        
+        if (this.parent) {
+            this.parent.childPropChanged(this, propName, oldValue, value);
+        }
 
         for (AweSnapper snapper in this.snappers) {
             for (model in snapper.allModels()) {
@@ -352,6 +360,9 @@ public class AweObject {
     extend public void propChanged(str propName, Object oldValue, Object newValue) {
     }        
 
+    extend public void childPropChanged(AweObject child, str propName, Object oldValue, Object newValue) {
+    }        
+
     extend public void buildQuickPropertiesFromSyntax(QuickProperties props) {
     }
 
@@ -384,9 +395,12 @@ public class AweObject {
     }
 
     extend public bool buildQuickProperties(QuickProperties props) {
+        this.parent.?buildQuickProperties(props);
+        
         this.buildQuickPropertiesFromSyntax(props);
         this.buildConnectorSetProperties(props);
         this.sortQuickProperties(props);
+        this.parent.?sortQuickProperties(props);
         
         return props and props.properties.any();
     }
@@ -402,6 +416,10 @@ public class AweObject {
     }
 
     extend public bool quickPropertyChanged(QuickProperties props, str key, Object value, bool testChangeOnly) {
+        if (this.parent.?quickPropertyChanged(..)) {
+            return true;
+        }
+
         var changed = false;
         
         if(!testChangeOnly)


### PR DESCRIPTION
- Allow programmer to define if model should build parent model quick properties
- Auto set parent object
- New trigger method for child models properties changed